### PR TITLE
Port mixin / AT changes from PFAATweaks to Source

### DIFF
--- a/src/main/java/com/cout970/magneticraft/Magneticraft.java
+++ b/src/main/java/com/cout970/magneticraft/Magneticraft.java
@@ -135,6 +135,10 @@ public class Magneticraft {
             MgMinetweaker.init();
         }
 
+        /*
+    PFAA uses a dedicated petrochem line for oil processing. Disable the addition of MgC fuels to BC, IE, and RC so
+    we have to refine our oil.
+
         if (ManagerIntegration.BUILDCRAFT) {
             ManagerFluids.registerBCFuels();
         }
@@ -146,6 +150,8 @@ public class Magneticraft {
         if (ManagerIntegration.IE) {
             ManagerFluids.registerIEFuels();
         }
+
+         */
 
         ForgeChunkManager.setForcedChunkLoadingCallback(INSTANCE, new MinerChunkCallBack());
 //		if(DEBUG)printOreDict();

--- a/src/main/java/com/cout970/magneticraft/api/util/EnergyConverter.java
+++ b/src/main/java/com/cout970/magneticraft/api/util/EnergyConverter.java
@@ -8,11 +8,11 @@ package com.cout970.magneticraft.api.util;
 public class EnergyConverter {
 
     //1W = 1J/t
-    public static final double RF_J = 10;            // 1RF = 10J | 1J = 0.1RF
-    public static final double EU_J = 40;            // 1EU = 40J | 1J = 0,025EU
-    public static final double STEAM_J = 20;        // 1mB = 20J | 1J = 0.05mB | 1 Burn tick = 5mB Steam = 100J
+    public static final double RF_J = 2.0;            // 1RF = 10J | 1J = 0.1RF
+    public static final double EU_J = 8.0;            // 1EU = 40J | 1J = 0,025EU
+    public static final double STEAM_J = 4.0;        // 1mB = 20J | 1J = 0.05mB | 1 Burn tick = 5mB Steam = 100J
     public static final double CALORIE_J = 0.2;    // 1cal = 0.2J | 1J = 5cal
-    public static final double FUEL_J = 100;        // 1 Burning tick = 100J
+    public static final double FUEL_J = 100.0;        // 1 Burning tick = 100J
     public static final double WATER_STEAM = 5;    // 1mB of Water = 5mB of Steam | 1mB Steam = 0.2 mB Water
     public static final double FUEL_CALORIE = 500; // 1 Burning tick = 500 cal | 1cal = 0.002 Burning ticks => 1mB Water == 5mB Steam | Calories needed to boil 1mB of water into 5mB of Steam
     public static final double MOL_MB = 8192;
@@ -131,7 +131,7 @@ public class EnergyConverter {
 	public static double PAtoPSI(double amount) {
 		return amount / PSI_PA;
 	}
-	
+
 	public static double PSItoPA(double amount) {
 		return amount * PSI_PA;
 	}

--- a/src/main/java/com/cout970/magneticraft/tileentity/multiblock/controllers/TileCrusher.java
+++ b/src/main/java/com/cout970/magneticraft/tileentity/multiblock/controllers/TileCrusher.java
@@ -59,10 +59,10 @@ public class TileCrusher extends TileMB_Base implements IGuiSync, IInventoryMana
             if (canCraft()) {
                 double speed = TileConductorLow.getEfficiency(cond.getVoltage(), ElectricConstants.MACHINE_WORK, ElectricConstants.BATTERY_CHARGE);
                 if (speed > 0) {
-                    speed *= 10;
+                    speed *= .5;
                     progress += speed;
-                    energy.addValue((float) EnergyConverter.RFtoW(speed * 10));
-                    cond.drainPower(EnergyConverter.RFtoW(speed * 10));
+                    energy.addValue((float) EnergyConverter.RFtoW(speed * 200));
+                    cond.drainPower(EnergyConverter.RFtoW(speed * 800));
                     if (progress >= MAX_PROGRESS) {
                         craft();
                         markDirty();

--- a/src/main/java/com/cout970/magneticraft/tileentity/multiblock/controllers/TileGrinder.java
+++ b/src/main/java/com/cout970/magneticraft/tileentity/multiblock/controllers/TileGrinder.java
@@ -69,10 +69,10 @@ public class TileGrinder extends TileMB_Base implements IInventoryManaged, ISide
             if (canCraft()) {
                 double speed = TileConductorLow.getEfficiency(cond.getVoltage(), ElectricConstants.MACHINE_WORK, ElectricConstants.BATTERY_CHARGE);
                 if (speed > 0) {
-                    speed *= 10;
+                    speed *= .5;
                     progress += speed;
-                    energy.addValue((float) EnergyConverter.RFtoW(speed * 10));
-                    cond.drainPower(EnergyConverter.RFtoW(speed * 10));
+                    energy.addValue((float) EnergyConverter.RFtoW(speed * 200));
+                    cond.drainPower(EnergyConverter.RFtoW(speed * 200));
                     if (progress >= maxProgress) {
                         craft();
                         markDirty();


### PR DESCRIPTION
Implements the following changes that were mixins

    Disable usage of MgC fuels in BC, IE and RC
    Update Energy calculation by adjusting the base speed in TileGrinder:updateEntity() (10.0, 10.0, 10.0 => 0.5, 200, 800)
    Update Energy calculation by adjusting the base speed in TileCrusher:updateEntity() (10.0, 10.0, 10.0 => 0.5, 200, 800)
    Update Energy conversion values
